### PR TITLE
fix(android): replace Kt ext with Java equivalent for compatibility

### DIFF
--- a/quill_native_bridge_android/android/src/main/kotlin/dev/flutterquill/quill_native_bridge/clipboard/ClipboardReadImageHandler.kt
+++ b/quill_native_bridge_android/android/src/main/kotlin/dev/flutterquill/quill_native_bridge/clipboard/ClipboardReadImageHandler.kt
@@ -175,7 +175,7 @@ object ClipboardReadImageHandler {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 // Api 29 and above (use a newer API)
                 val source = ImageDecoder.createSource(context.contentResolver, imageUri)
-                source.decodeBitmap { _, _ -> }
+                ImageDecoder.decodeBitmap(source)
             } else {
                 // Backward compatibility with older versions
                 checkNotNull(context.contentResolver.openInputStream(imageUri)) {

--- a/quill_native_bridge_android/android/src/main/kotlin/dev/flutterquill/quill_native_bridge/clipboard/ClipboardReadImageHandler.kt
+++ b/quill_native_bridge_android/android/src/main/kotlin/dev/flutterquill/quill_native_bridge/clipboard/ClipboardReadImageHandler.kt
@@ -8,7 +8,6 @@ import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import android.net.Uri
 import android.os.Build
-import androidx.core.graphics.decodeBitmap
 import dev.flutterquill.quill_native_bridge.generated.FlutterError
 import java.io.ByteArrayOutputStream
 import java.io.FileNotFoundException


### PR DESCRIPTION
This change supports older versions of the Android Gradle Plugin (AGP) and ensures consistency with `ClipboardWriteImageHandler.copyImageToClipboard()` [similar usage of `ImageDecoder.decodeBitmap`](https://github.com/FlutterQuill/quill-native-bridge/blob/3165de2b4e2c43b32cdf425c3b12ed62545ad030/quill_native_bridge_android/android/src/main/kotlin/dev/flutterquill/quill_native_bridge/clipboard/ClipboardWriteImageHandler.kt#L22).

- *Fix https://github.com/singerdmx/flutter-quill/issues/2340*