### PR TITLE
upgrade to win32 v6

### DIFF
--- a/quill_native_bridge_windows/lib/quill_native_bridge_windows.dart
+++ b/quill_native_bridge_windows/lib/quill_native_bridge_windows.dart
@@ -44,7 +44,7 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
   /// Refer to [Windows GetClipboardData() docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getclipboarddata)
   @override
   Future<String?> getClipboardHtml() async {
-    if (OpenClipboard(NULL) == FALSE) {
+    if (OpenClipboard(null) == FALSE) {
       assert(
         false,
         'Unknown error while opening the clipboard. Error code: ${GetLastError()}',
@@ -73,8 +73,9 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
         return null;
       }
 
-      final clipboardDataPointer = Pointer.fromAddress(clipboardDataHandle);
-      final lockedMemoryPointer = GlobalLock(clipboardDataPointer);
+      final clipboardDataPointer =
+          Pointer.fromAddress(clipboardDataHandle.value.address);
+      final lockedMemoryPointer = GlobalLock(HGLOBAL(clipboardDataPointer));
       if (lockedMemoryPointer == nullptr) {
         assert(
           false,
@@ -84,8 +85,8 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
       }
 
       final windowsHtmlWithMetadata =
-          lockedMemoryPointer.cast<Utf8>().toDartString();
-      GlobalUnlock(clipboardDataPointer);
+          lockedMemoryPointer.value.cast<Utf8>().toDartString();
+      GlobalUnlock(HGLOBAL(clipboardDataPointer));
 
       // Strip comments/headers at the start of the HTML as they can cause
       // issues while parsing the HTML
@@ -102,7 +103,7 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
   /// Refer to [Windows SetClipboardData() docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata)
   @override
   Future<void> copyHtmlToClipboard(String html) async {
-    if (OpenClipboard(NULL) == FALSE) {
+    if (OpenClipboard(null) == FALSE) {
       assert(
         false,
         'Unknown error while opening the clipboard. Error code: ${GetLastError()}',
@@ -136,7 +137,8 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
       final htmlSize = (htmlPointer.length + 1) * unitSize;
 
       final clipboardMemoryHandle = GlobalAlloc(GMEM_MOVEABLE, htmlSize);
-      if (clipboardMemoryHandle == nullptr) {
+      if (clipboardMemoryHandle == nullptr ||
+          !clipboardMemoryHandle.error.isOk) {
         assert(
           false,
           'Failed to allocate memory for the clipboard content. Error code: ${GetLastError()}',
@@ -144,9 +146,9 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
         return;
       }
 
-      final lockedMemoryPointer = GlobalLock(clipboardMemoryHandle);
+      final lockedMemoryPointer = GlobalLock(clipboardMemoryHandle.value);
       if (lockedMemoryPointer == nullptr) {
-        GlobalFree(clipboardMemoryHandle);
+        GlobalFree(clipboardMemoryHandle.value);
         assert(
           false,
           'Failed to lock global memory. Error code: ${GetLastError()}',
@@ -154,7 +156,7 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
         return;
       }
 
-      final targetMemoryPointer = lockedMemoryPointer.cast<Uint8>();
+      final targetMemoryPointer = lockedMemoryPointer.value.cast<Uint8>();
 
       final sourcePointer = htmlPointer.cast<Uint8>();
 
@@ -170,11 +172,11 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
       // Should not call GlobalFree() when SetClipboardData() success
       // as the Windows clipboard takes ownership of the memory.
 
-      GlobalUnlock(clipboardMemoryHandle);
+      GlobalUnlock(clipboardMemoryHandle.value);
 
-      if (SetClipboardData(htmlFormatId, clipboardMemoryHandle.address) ==
+      if (SetClipboardData(htmlFormatId, HANDLE(clipboardMemoryHandle.value)) ==
           NULL) {
-        GlobalFree(clipboardMemoryHandle);
+        GlobalFree(clipboardMemoryHandle.value);
         assert(
           false,
           'Failed to set the clipboard data: ${GetLastError()}',
@@ -219,10 +221,11 @@ class QuillNativeBridgeWindows extends QuillNativeBridgePlatform {
 
   @override
   Future<void> openGalleryApp() async {
-    final uriPtr = TEXT('ms-photos:');
-    final openPtr = 'open'.toNativeUtf16();
+    final uriPtr = 'ms-photos:'.toPcwstr();
+    final openPtr = 'open'.toPcwstr();
 
-    ShellExecute(NULL, openPtr, uriPtr, nullptr, nullptr, SW_SHOWNORMAL);
+    ShellExecute(
+        null, openPtr, uriPtr, PCWSTR(nullptr), PCWSTR(nullptr), SW_SHOWNORMAL);
 
     free(uriPtr);
     free(openPtr);

--- a/quill_native_bridge_windows/lib/src/clipboard_html_format.dart
+++ b/quill_native_bridge_windows/lib/src/clipboard_html_format.dart
@@ -18,14 +18,14 @@ extension ClipboardHtmlFormatExt on QuillNativeBridgeWindows {
   }
 
   int? _registerHtmlFormat() {
-    final htmlFormatPointer = TEXT(_kHtmlFormatName);
+    final htmlFormatPointer = _kHtmlFormatName.toPcwstr();
     final htmlFormatId = RegisterClipboardFormat(htmlFormatPointer);
     free(htmlFormatPointer);
 
-    if (htmlFormatId == NULL) {
+    if (htmlFormatId == NULL || !htmlFormatId.error.isOk) {
       // When error occurs
       return null;
     }
-    return htmlFormatId;
+    return htmlFormatId.value;
   }
 }

--- a/quill_native_bridge_windows/pubspec.yaml
+++ b/quill_native_bridge_windows/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   quill_native_bridge_platform_interface: ^0.0.1
-  win32: ^5.5.0
+  win32: ^6.2.0
   ffi: ^2.1.0
   file_selector_windows: ^0.9.1+5
   file_selector_platform_interface: ^2.4.0


### PR DESCRIPTION
# IMPORTANT: This has not been tested on actual Windows

No AI has been used to write the code, **but** I have never worked with the win32 API through Flutter or directly, nor do I use Windows as an OS. 

While the tests passed and Flutter reports no problems, the actual functionality might still be broken. Therefore, closing this PR is completely understandable. Maintainers have write access to the branch though.

These changes mainly come from the migratio guide <https://win32.pub/docs/migration/5xx-to-6xx> or from wrapping the current types in values that the methods now have as a signature. Since they (wrapper types?) still fit the old values, it looks like, from a general developer standpoint, it should work and was just added to provide more options for the types/better type handling.

`quill_native_bridge_winodws` is unfortunately still one of the few packages that does not support the win32 v6 version released two months ago. Allowing v6 / 6.2.0 would be a big help